### PR TITLE
fix(shannon/fullnode): limit storage mounting to data folder

### DIFF
--- a/templates/shannon/deployment.yaml
+++ b/templates/shannon/deployment.yaml
@@ -25,9 +25,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.shannon.relayminer.podSecurityContext }}
+      {{- with .Values.shannon.relayminer.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.shannon.relayminer.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
         {{- include "pocket-network.shannon.initcontainers.relayminer.working-directory" . | nindent 8 }}

--- a/templates/shannon/statefulset.yaml
+++ b/templates/shannon/statefulset.yaml
@@ -27,9 +27,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.shannon.fullnode.podSecurityContext }}
+      {{- with .Values.shannon.fullnode.podSecurityContext }}
       securityContext:
-        {{- toYaml | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
         {{- include "pocket-network.shannon.initcontainers.fullnode.cosmossdk" . | nindent 8 }}
@@ -119,8 +119,14 @@ spec:
           resources: {{- toYaml .Values.shannon.fullnode.resources.values | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: working-directory-config
+              mountPath: "{{ .Values.workingDirectory }}/config"
             - name: working-directory
-              mountPath: "{{ .Values.workingDirectory }}"
+              mountPath: "{{ .Values.workingDirectory }}/data"
+              subPath: data
+            - name: working-directory
+              mountPath: "{{ .Values.workingDirectory }}/snapshot"
+              subPath: snapshot
             - name: cosmossdk-config
               mountPath: "{{ .Values.workingDirectory }}/config/config.toml"
               subPath: "{{ .Values.shannon.fullnode.cosmossdk.volumes.config.key.configKeyName }}"
@@ -169,6 +175,8 @@ spec:
           {{- include "pocket-network.shannon.envs.cosmosvisor" . | nindent 10 }}
           {{- end }}
       volumes:
+        - name: working-directory-config
+          emptyDir: {}
         - name: cosmossdk-config
           configMap:
             {{- if .Values.shannon.fullnode.cosmossdk.volumes.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -1546,30 +1546,18 @@ shannon:
     #   runAsGroup: 3000        # Run the Pod as group ID 3000
     #   fsGroup: 2000           # Set file system group ownership to 2000
     podSecurityContext: {}
-    # initContainersSecurityContext are key-values pairs to define the
-    # security settings for all init containers. This field overwrites
-    # the podSecurityContext settings if any defined.
-    #
-    # e.g
-    # initContainers:
-    #   runAsUser: 1000         # Run the Pod as user ID 1000
-    #   runAsGroup: 3000        # Run the Pod as group ID 3000
-    #   fsGroup: 2000           # Set file system group ownership to 2000
-    initContainersSecurityContext:
-      runAsUser: 1025
-      runAsGroup: 1025
     # securityContext are key-values pairs to define the security settings
     # for the fullnode pod containers. This field overwrites the
     # podSecurityContext settings if any defined.
     #
+    #
     # e.g.
-    # capabilities:
-    #     drop:
-    #     - ALL
-    #   readOnlyRootFilesystem: true
-    #   runAsNonRoot: true
-    #   runAsUser: 1000
-    containersSecurityContext: {}
+    # containersSecurityContext
+    #   runAsUser: 1025
+    #   runAsGroup: 1025
+    containersSecurityContext:
+      runAsUser: 1025
+      runAsGroup: 1025
     # nodeSelector are key-values pairs to schedule the fullnode pod on a
     # specific node based on labels.
     nodeSelector: {}


### PR DESCRIPTION
This PR limits the `.shannon.fullnode.storage` mounting to the `data` folder due to remaining/unwanted files while in the mounted volumes (key files, for example).