### PR TITLE
feat(shannon/relayminer): add  `.Values.development.relay` Kubernetes CronJob to simulate relays

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,14 +515,28 @@ object
 			<td></td>
 		</tr>
 		<tr>
-			<td id="shannon--fullnode--containersSecurityContext">shannon.fullnode.containersSecurityContext</td>
+			<td id="shannon--fullnode--containersSecurityContext--runAsGroup">shannon.fullnode.containersSecurityContext.runAsGroup</td>
 			<td>
-object
+int
 </td>
 			<td>
 				<div style="max-width: 300px;">
 <pre lang="json">
-{}
+1025
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--fullnode--containersSecurityContext--runAsUser">shannon.fullnode.containersSecurityContext.runAsUser</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1025
 </pre>
 </div>
 			</td>
@@ -993,34 +1007,6 @@ list
 				<div style="max-width: 300px;">
 <pre lang="json">
 []
-</pre>
-</div>
-			</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td id="shannon--fullnode--initContainersSecurityContext--runAsGroup">shannon.fullnode.initContainersSecurityContext.runAsGroup</td>
-			<td>
-int
-</td>
-			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1025
-</pre>
-</div>
-			</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td id="shannon--fullnode--initContainersSecurityContext--runAsUser">shannon.fullnode.initContainersSecurityContext.runAsUser</td>
-			<td>
-int
-</td>
-			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1025
 </pre>
 </div>
 			</td>
@@ -1949,14 +1935,28 @@ string
 			<td></td>
 		</tr>
 		<tr>
-			<td id="shannon--relayminer--containersSecurityContext">shannon.relayminer.containersSecurityContext</td>
+			<td id="shannon--relayminer--containersSecurityContext--runAsGroup">shannon.relayminer.containersSecurityContext.runAsGroup</td>
 			<td>
-object
+int
 </td>
 			<td>
 				<div style="max-width: 300px;">
 <pre lang="json">
-{}
+1025
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--containersSecurityContext--runAsUser">shannon.relayminer.containersSecurityContext.runAsUser</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1025
 </pre>
 </div>
 			</td>
@@ -2027,6 +2027,230 @@ bool
 				<div style="max-width: 300px;">
 <pre lang="json">
 true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--activeDeadlineSeconds">shannon.relayminer.development.relay.activeDeadlineSeconds</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+600
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--application--address">shannon.relayminer.development.relay.application.address</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"pokt10v4ta463vmul6ztfzj2ts55rwmh9scdxzaaj9f"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--application--secret--keyName">shannon.relayminer.development.relay.application.secret.keyName</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"mnemonic.txt"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--application--secret--name">shannon.relayminer.development.relay.application.secret.name</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"pocket-network-shannon-application-key"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--backoffLimit">shannon.relayminer.development.relay.backoffLimit</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+3
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--completions">shannon.relayminer.development.relay.completions</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--count">shannon.relayminer.development.relay.count</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+100
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--enabled">shannon.relayminer.development.relay.enabled</td>
+			<td>
+bool
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--nodeGrpc--insecure">shannon.relayminer.development.relay.nodeGrpc.insecure</td>
+			<td>
+bool
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--nodeGrpc--url">shannon.relayminer.development.relay.nodeGrpc.url</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"tcp://node:9090"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--nodeRpcUrl">shannon.relayminer.development.relay.nodeRpcUrl</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"tcp://node:26657"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--parallelism">shannon.relayminer.development.relay.parallelism</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--payload">shannon.relayminer.development.relay.payload</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"eth_blockNumber\", \"params\": []}"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--schedule">shannon.relayminer.development.relay.schedule</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"*/5 * * * *"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--supplierAddress">shannon.relayminer.development.relay.supplierAddress</td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"pokt19a3t4yunp0dlpfjrp7qwnzwlrzd5fzs2gjaaaj"
+</pre>
+</div>
+			</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td id="shannon--relayminer--development--relay--ttlSecondsAfterFinished">shannon.relayminer.development.relay.ttlSecondsAfterFinished</td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+5
 </pre>
 </div>
 			</td>
@@ -2209,34 +2433,6 @@ list
 				<div style="max-width: 300px;">
 <pre lang="json">
 []
-</pre>
-</div>
-			</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td id="shannon--relayminer--initContainersSecurityContext--runAsGroup">shannon.relayminer.initContainersSecurityContext.runAsGroup</td>
-			<td>
-int
-</td>
-			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1025
-</pre>
-</div>
-			</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td id="shannon--relayminer--initContainersSecurityContext--runAsUser">shannon.relayminer.initContainersSecurityContext.runAsUser</td>
-			<td>
-int
-</td>
-			<td>
-				<div style="max-width: 300px;">
-<pre lang="json">
-1025
 </pre>
 </div>
 			</td>
@@ -2558,7 +2754,7 @@ string
 			<td>
 				<div style="max-width: 300px;">
 <pre lang="json">
-"0.1.21"
+"0.1.24"
 </pre>
 </div>
 			</td>

--- a/examples/relayminer/relays/README.md
+++ b/examples/relayminer/relays/README.md
@@ -1,6 +1,6 @@
 # Deploy a Kubernetes CronJob to simulate relays
 
-For development and performance analysis purposes, a Pocket Network Node Operator might want to send many requests in the test environment (`alpha` or `beta` for example) to see how the relayminer, and downstream services behaves in a controlled computer system. This Helm chart enables you to configure a Kubernetes CronJob that will send a fix total amount of relay requests to a relayminer instance for an Application.
+To support development and performance analysis, a Pocket Network Node Operator may need to send a high volume of requests in a test environments (such as `alpha` or `beta`) to observe the behavior of the relayminer and downstream services in a controlled setup. This Helm Chart configures a Kubernetes CronJob to send a fixed number of relay requests to a relayminer instance on behalf of an Application.
 
 For more information, please refer to this pull request: https://github.com/pokt-network/poktroll/pull/1539
 
@@ -8,11 +8,9 @@ For more information, please refer to this pull request: https://github.com/pokt
 
 1. 1 Supplier and 1 Application staked.
 2. Relayminer up and running with staked supplier defined in 1.
-3. Fullnode up and running exposing RPC and gRPC endpoints.
+3. Fullnode up and running exposing the RPC and gRPC endpoints.
 
-# 
-
-In this `values.yaml` example, we are goint o deploy a Kubernetes CronJob that is scheduled every 3 minutes to send 20K relay requests to a relayminer instance for a specified application and supplier.
+In this `values.yaml` example, we are going to deploy a Kubernetes CronJob that is scheduled every 3 minutes to send 20K relay requests to a relayminer instance for a specified application and supplier.
 
 ```shell
 ?> helm install <release-name> . -f examples/relayminer/relays/values.yaml

--- a/examples/relayminer/relays/README.md
+++ b/examples/relayminer/relays/README.md
@@ -1,0 +1,19 @@
+# Deploy a Kubernetes CronJob to simulate relays
+
+For development and performance analysis purposes, a Pocket Network Node Operator might want to send many requests in the test environment (`alpha` or `beta` for example) to see how the relayminer, and downstream services behaves in a controlled computer system. This Helm chart enables you to configure a Kubernetes CronJob that will send a fix total amount of relay requests to a relayminer instance for an Application.
+
+For more information, please refer to this pull request: https://github.com/pokt-network/poktroll/pull/1539
+
+## Pre-requisite
+
+1. 1 Supplier and 1 Application staked.
+2. Relayminer up and running with staked supplier defined in 1.
+3. Fullnode up and running exposing RPC and gRPC endpoints.
+
+# 
+
+In this `values.yaml` example, we are goint o deploy a Kubernetes CronJob that is scheduled every 3 minutes to send 20K relay requests to a relayminer instance for a specified application and supplier.
+
+```shell
+?> helm install <release-name> . -f examples/relayminer/relays/values.yaml
+```

--- a/examples/relayminer/relays/values.yaml
+++ b/examples/relayminer/relays/values.yaml
@@ -34,8 +34,6 @@ shannon:
       repository: ghcr.io/pokt-network/pocketd
       pullPolicy: IfNotPresent
       tag: ""
-    imagePullSecrets: []
-    podSecurityContext: {}
     containersSecurityContext:
       runAsUser: 1025
       runAsGroup: 1025

--- a/examples/relayminer/relays/values.yaml
+++ b/examples/relayminer/relays/values.yaml
@@ -1,0 +1,46 @@
+protocol: shannon
+chain: pocket-beta
+version: 0.1.24
+workingDirectory: /home/pocket/.pocket
+shannon:
+  relayminer:
+    development:
+      relay:
+        enabled: true
+        schedule: "*/3 * * * *"
+        suspend: false
+        count: 20000
+        application:
+          address: <your-app-address>
+          secret:
+            name: pocket-network-shannon-beta-application-key
+            keyName: mnemonic.txt
+        supplierAddress: <your-supplier-address>
+        nodeRpcUrl: tcp://node:26657
+        nodeGrpc:
+          url: node:9090
+          insecure: true
+        payload:
+          jsonrpc: "2.0"
+          id: 1
+          method: eth_blockNumber
+          params: []
+        parallelism: 10
+        completions: 10
+        backoffLimit: 3
+        activeDeadlineSeconds: 600
+        ttlSecondsAfterFinished: 10
+    image:
+      repository: ghcr.io/pokt-network/pocketd
+      pullPolicy: IfNotPresent
+      tag: ""
+    imagePullSecrets: []
+    podSecurityContext: {}
+    containersSecurityContext:
+      runAsUser: 1025
+      runAsGroup: 1025
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  fullnode:
+    enabled: false

--- a/templates/shannon/cronjob.yaml
+++ b/templates/shannon/cronjob.yaml
@@ -1,0 +1,90 @@
+{{- if and .Values.protocol "shannon" .Values.shannon.relayminer.development.relay.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "pocket-network.fullname" . }}-shannon-relay
+  labels:
+    {{- include "pocket-network.labels" (dict "root" . "nameSuffix" "shannon-relayminer" ) | nindent 4 }}
+spec:
+  schedule: "{{ .Values.shannon.relayminer.development.relay.schedule }}"
+  suspend: {{ .Values.shannon.relayminer.development.relay.suspend }}
+  jobTemplate:
+    spec:
+      parallelism: {{ .Values.shannon.relayminer.development.relay.parallelism }}
+      completions: {{ .Values.shannon.relayminer.development.relay.completions }}
+      backoffLimit: {{ .Values.shannon.relayminer.development.relay.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.shannon.relayminer.development.relay.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.shannon.relayminer.development.relay.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          labels:
+            {{- include "pocket-network.labels" (dict "root" . "nameSuffix" "shannon-relayminer" ) | nindent 12 }}
+        spec:
+          initContainers:
+            {{- include "pocket-network.shannon.initcontainers.relayminer.working-directory" . | nindent 12 }}
+          containers:
+          - name: "relayminer"
+            {{- with .Values.shannon.relayminer.containersSecurityContext }}
+            securityContext:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+            image: "{{ .Values.shannon.relayminer.image.repository }}:{{ .Values.shannon.relayminer.image.tag | default .Values.version }}"
+            imagePullPolicy: {{ .Values.shannon.relayminer.image.pullPolicy }}
+            command:
+              - "/bin/sh"
+              - "-c"
+              - |
+                pocketd keys add \
+                {{ .Values.shannon.relayminer.development.relay.application.address }} \
+                --recover \
+                --home={{ .Values.workingDirectory }} \
+                --keyring-backend=test \
+                --source={{ .Values.workingDirectory }}/{{ .Values.shannon.relayminer.development.relay.application.secret.keyName }};
+
+                pocketd \
+                relayminer \
+                relay \
+                --home={{ .Values.workingDirectory }} \
+                --count={{ .Values.shannon.relayminer.development.relay.count }} \
+                --app={{ .Values.shannon.relayminer.development.relay.application.address }} \
+                {{- if .Values.shannon.relayminer.development.relay.supplierAddress }}
+                --supplier={{ .Values.shannon.relayminer.development.relay.supplierAddress }} \
+                {{- end }}
+                --keyring-backend=test \
+                --node={{ .Values.shannon.relayminer.development.relay.nodeRpcUrl }} \
+                --grpc-addr={{ .Values.shannon.relayminer.development.relay.nodeGrpc.url }} \
+                --grpc-insecure={{ .Values.shannon.relayminer.development.relay.nodeGrpc.insecure }} \
+                --payload={{ .Values.shannon.relayminer.development.relay.payload | toJson | quote }}
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                cpu: 50m
+                memory: 256Mi
+            volumeMounts:
+              - name: working-directory
+                mountPath: "{{ .Values.workingDirectory }}"
+              - name: keys-application
+                mountPath: "{{ .Values.workingDirectory }}/{{ .Values.shannon.relayminer.development.relay.application.secret.keyName }}"
+                subPath: "{{ .Values.shannon.relayminer.development.relay.application.secret.keyName }}"
+          {{- with .Values.shannon.relayminer.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.shannon.relayminer.affinity }}
+          affinity:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.shannon.relayminer.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          volumes:
+            - name: working-directory
+              emptyDir: {}
+            - name: keys-application
+              secret:
+                secretName: {{ .Values.shannon.relayminer.development.relay.application.secret.name }}
+          restartPolicy: OnFailure
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,7 @@ chain: pocket-beta
 # software.
 #
 # see https://github.com/pokt-network/poktroll/releases
-version: 0.1.21
+version: 0.1.24
 
 # workingDirectory refers to the pocketd working directory. This variable is
 # shared across all every procol actors. Meaning that the working directory
@@ -211,9 +211,52 @@ shannon:
       serviceMonitor:
         # activates the templating of a ServiceMonitor custom resource.
         enabled: true
-    # development are the globals configuration to set up an development
-    # environment on the relayminer pod.
+    # development are the globals configuration to set up a development
+    # environment to test or analyze the relayminer pod.
     development:
+      # relay configures a Kubernetes CronJob to simulate real-word requests and
+      # response between a staked Application and Supplier.
+      # Before running this CronJob, you must staked an application and a
+      # supplier.
+      relay:
+        # actives the Kubernetes CronJob.
+        enabled: false
+        # defines the schedule time using the Cron syntax
+        # https://en.wikipedia.org/wiki/Cron
+        schedule: "*/10 * * * *"
+        # defines the number of requests to send.
+        count: 100
+        # defines the staked application address.
+        application:
+          address: pokt10v4ta463vmul6ztfzj2ts55rwmh9scdxzaaj9f
+          secret:
+            name: pocket-network-shannon-application-key
+            keyName: mnemonic.txt
+        # (optional) defines the staked supplier address exposing the
+        # service. If not defined, the Kubernetes CronJob will stake
+        # a random Supplier from the staked Application.
+        # For now, the supplier must staked a single service.
+        supplierAddress: pokt19a3t4yunp0dlpfjrp7qwnzwlrzd5fzs2gjaaaj
+        # configures a websocket connection to a pocket network node.
+        nodeRpcUrl: tcp://node:26657
+        # configures RPC connection to a pocket network node.
+        nodeGrpc:
+          # defines the URL to connect to.
+          url: tcp://node:9090
+          # disable the transport security layer.
+          insecure: true
+        # define the request payload to send for each requests in JSON.
+        payload: "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"eth_blockNumber\", \"params\": []}"
+        # Number of pods to run in parallel.
+        parallelism: 1
+        # Total number of completions required for a successful CronJob execution.
+        completions: 1
+        # Number of retries before giving up.
+        backoffLimit: 3
+        # Time limit for the job (in seconds).
+        activeDeadlineSeconds: 1800
+        # Time to keep the Job resource around after completion.
+        ttlSecondsAfterFinished: 7200
       # delve configures a debugger for the Go programming language. Keep in
       # mind that debugging may be challenging if the binary was compiled
       # with optimizations and inlining enabled.
@@ -369,39 +412,24 @@ shannon:
     # podSecurityContext are key-values pairs to define the security settings
     # for all containers within a pod.
     #
-    # e.g.
+    # e.g.:
     #
-    # podSecurityContext
+    # podSecurityContext:
     #   runAsUser: 1000         # Run the Pod as user ID 1000
     #   runAsGroup: 3000        # Run the Pod as group ID 3000
-    #   fsGroup: 2000           # Set file system group ownership to 2000
     podSecurityContext: {}
-    # initContainersSecurityContext are key-values pairs to define the
-    # security settings for all init containers. This field overwrites
-    # the podSecurityContext settings if any defined.
-    #
-    # e.g.
-    #
-    # initContainers:
-    #   runAsUser: 1000         # Run the Pod as user ID 1000
-    #   runAsGroup: 3000        # Run the Pod as group ID 3000
-    #   fsGroup: 2000           # Set file system group ownership to 2000
-    initContainersSecurityContext:
-      runAsUser: 1025
-      runAsGroup: 1025
     # securityContext are key-values pairs to define the security settings
     # for the relayminer pod containers. This field overwrites the
     # podSecurityContext settings if any defined.
     #
-    # e.g.
+    # e.g.:
     #
-    # capabilities:
-    #     drop:
-    #     - ALL
-    #   readOnlyRootFilesystem: true
-    #   runAsNonRoot: true
-    #   runAsUser: 1000
-    containersSecurityContext: {}
+    # containersSecurityContext:
+    #   runAsUser: 1000         # Run the Pod as user ID 1000
+    #   runAsGroup: 3000        # Run the Pod as group ID 3000
+    containersSecurityContext:
+      runAsUser: 1025
+      runAsGroup: 1025
     # nodeSelector are key-values pairs to schedule the relayminer pod on a
     # specific node based on labels.
     nodeSelector: {}

--- a/values.yaml
+++ b/values.yaml
@@ -223,7 +223,7 @@ shannon:
         enabled: false
         # defines the schedule time using the Cron syntax
         # https://en.wikipedia.org/wiki/Cron
-        schedule: "*/10 * * * *"
+        schedule: "*/5 * * * *"
         # defines the number of requests to send.
         count: 100
         # defines the staked application address.
@@ -248,15 +248,15 @@ shannon:
         # define the request payload to send for each requests in JSON.
         payload: "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"eth_blockNumber\", \"params\": []}"
         # Number of pods to run in parallel.
-        parallelism: 1
+        parallelism: 5
         # Total number of completions required for a successful CronJob execution.
-        completions: 1
+        completions: 5
         # Number of retries before giving up.
         backoffLimit: 3
         # Time limit for the job (in seconds).
-        activeDeadlineSeconds: 1800
+        activeDeadlineSeconds: 600
         # Time to keep the Job resource around after completion.
-        ttlSecondsAfterFinished: 7200
+        ttlSecondsAfterFinished: 5
       # delve configures a debugger for the Go programming language. Keep in
       # mind that debugging may be challenging if the binary was compiled
       # with optimizations and inlining enabled.

--- a/values.yaml
+++ b/values.yaml
@@ -233,9 +233,9 @@ shannon:
             name: pocket-network-shannon-application-key
             keyName: mnemonic.txt
         # (optional) defines the staked supplier address exposing the
-        # service. If not defined, the Kubernetes CronJob will stake
-        # a random Supplier from the staked Application.
-        # For now, the supplier must staked a single service.
+        # service. If not defined, the Kubernetes CronJob will select
+        # a random Supplier. For now, the supplier must staked a
+        # single service.
         supplierAddress: pokt19a3t4yunp0dlpfjrp7qwnzwlrzd5fzs2gjaaaj
         # configures a websocket connection to a pocket network node.
         nodeRpcUrl: tcp://node:26657


### PR DESCRIPTION
This PR adds the capability to deploy a Kubernetes CronJob that simulates relays from an Application to a Supplier